### PR TITLE
Remove `feature(file_create_new)` from crate specification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@
   license      = "MIT"
   readme       = "README.md"
   repository   = "https://github.com/voidei/json2toml"
-  rust-version = "1.66"
+  rust-version = "1.77"
 
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(file_create_new)]
 use std::{
     fs::{
         self,


### PR DESCRIPTION
The crate flag `#![feature(file_create_new)]` is no longer needed, as `File::create_new` is stable as of Rust 1.77. This removes the feature specification and sets the minimum Rust version to 1.77.

I did not remove the toolchain specification from `rust-toolchain.toml`, as the use of `out-dir` requires the nightly channel and I did not want to mess with release processes. This merely enables people to `cargo install json2toml` directly.